### PR TITLE
Fix explicit __typename selection

### DIFF
--- a/src/compiler/__tests__/__snapshots__/compile.test.ts.snap
+++ b/src/compiler/__tests__/__snapshots__/compile.test.ts.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`explicit typename 1`] = `
+"function extractClass(obj) {
+  const s = ObjectSpecifier.classOf(eval(Automation.getDisplayString(obj)));
+  return (s.match(/[a-zA-Z0-9]+/g) || [])
+    .map((w) => \`\${w[0].toUpperCase()}\${w.slice(1)}\`)
+    .join(\\"\\");
+}
+function extractId(obj) {
+  const spec = Automation.getDisplayString(obj);
+  if (spec === undefined) {
+    return null;
+  }
+  let inParen = false;
+  let inStr = false;
+  let ret = \\"\\";
+  let nextEscape = null;
+  for (let i = 0; i < spec.length; i++) {
+    const c = spec[i];
+    const inEscape = nextEscape === i;
+    if (c === \\"\\\\\\\\\\") {
+      nextEscape = i + 1;
+      continue;
+    }
+    if (!inEscape && c === '\\"') {
+      inStr = !inStr;
+      continue;
+    }
+    if (!inStr) {
+      if (c === \\"(\\") {
+        inParen = true;
+        ret = \\"\\";
+        continue;
+      }
+      if (c === \\")\\") {
+        inParen = false;
+        continue;
+      }
+    }
+    ret = \`\${ret}\${c}\`;
+  }
+  return ret !== \\"\\" ? ret : null;
+}
+const app = Application(\\"OmniFocus\\");
+JSON.stringify({
+  result: {
+    defaultDocument: {
+      sections: (() => {
+        const allNodes = app.defaultDocument().sections();
+        const nodes = allNodes;
+        return {
+          edges: nodes.map((elm) => {
+            return {
+              node: { __typename: extractClass(elm), id: extractId(elm) },
+            };
+          }),
+        };
+      })(),
+    },
+  },
+});
+"
+`;
+
 exports[`query for Connection 1`] = `
 "function extractClass(obj) {
   const s = ObjectSpecifier.classOf(eval(Automation.getDisplayString(obj)));

--- a/src/compiler/__tests__/compile.test.ts
+++ b/src/compiler/__tests__/compile.test.ts
@@ -224,3 +224,32 @@ test("typename", async () => {
 
   expect(prettier.format(compile("OmniFocus", exeContext as any), { parser: "babel" })).toMatchSnapshot();
 });
+
+test("explicit typename", async () => {
+  const document = gql`
+    query {
+      application {
+        defaultDocument {
+          sections {
+            edges {
+              node {
+                id
+                __typename
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const exeContext = buildExecutionContext({
+    schema: await schema,
+    document: document,
+  });
+  if (!validateExecontext(exeContext)) {
+    console.log(exeContext);
+  }
+
+  expect(prettier.format(compile("OmniFocus", exeContext as any), { parser: "babel" })).toMatchSnapshot();
+});

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,4 +1,4 @@
-import { assertSome } from "@graphql-tools/utils";
+import { assertSome, isSome } from "@graphql-tools/utils";
 import {
   FieldNode,
   GraphQLResolveInfo,
@@ -16,6 +16,8 @@ import {
   InlineFragmentNode,
   FragmentSpreadNode,
 } from "graphql";
+import { name } from "../converter/name";
+import { nonNull } from "../converter/types";
 import { unwrapType } from "../graphql-utils";
 import { bundle, join, RenderResult, VariableDependency } from "./bundler";
 import { AvailableKeys, buildLibrary, FUNCS } from "./jxalib";
@@ -242,7 +244,7 @@ const renderFields = (
   const objectDef = mustFindTypeDefinition(ctx, object.typeNode);
   const isRecordType = hasDirective(objectDef, "recordType");
 
-  const reflectionRequired =
+  let reflectionRequired =
     withReflection !== undefined ? withReflection : objectDef.kind === Kind.INTERFACE_TYPE_DEFINITION;
 
   const fields = object.selectedFields.map((field) => {
@@ -251,6 +253,10 @@ const renderFields = (
     }
     if (field.kind === Kind.FRAGMENT_SPREAD) {
       return renderFragmentSpread(ctx, field, object.parentName);
+    }
+    if (field.name.value === "__typename") {
+      reflectionRequired = true;
+      return null;
     }
     const definition = objectDef.fields?.find((def) => def.name.value === field.name.value);
     assertSome(definition);
@@ -261,7 +267,7 @@ const renderFields = (
     fields.push(bundle`__typename: ${FUNCS.extractClass}(${object.parentName}),`);
   }
 
-  return join(fields);
+  return join(fields.filter(isSome));
 };
 
 export const compile = (


### PR DESCRIPTION
## WHY

When accessing the `__typename` field explicitly, it crashes because no field definition can not be found for that name.

## WHAT

Since `__typename` is a special field, we should not try to find a definition at all to fallback to reflection.